### PR TITLE
Remove 20 agent pool per organization limit

### DIFF
--- a/website/docs/cloud-docs/agents/index.mdx
+++ b/website/docs/cloud-docs/agents/index.mdx
@@ -79,8 +79,6 @@ Agents allow you to run Terraform operations from a Terraform Cloud workspace on
 
 For these use cases, we recommend you leverage the information provided by the [IP Ranges documentation](/cloud-docs/architectural-details/ip-ranges) to permit direct communication from the appropriate Terraform Cloud service to your internal infrastructure.
 
-Organizations are limited to 20 pools each.
-
 ### Terraform Enterprise
 
 Terraform Enterprise supports Terraform Cloud Agents; see


### PR DESCRIPTION
The limit on the number of agent pools in TFC is being removed.

We will merge this once the remove-agent-pool-limit feature flag is enabled

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202293596899904