### PR TITLE
added documentation for scoping agent pools to workspaces on agents page

### DIFF
--- a/website/docs/cloud-docs/agents/index.mdx
+++ b/website/docs/cloud-docs/agents/index.mdx
@@ -127,6 +127,24 @@ Agents are organized into pools, which can be managed in Terraform Cloud's UI. E
 
    ![Screenshot: Unable to delete an agent pool with attached workspace](/img/docs/agent-delete-invalid.png)
 
+### Scope an Agent Pool to Specific Workspaces
+
+Scoping an agent pool lets you specify which workspaces are allowed to use it. The agent pool will then only be available from within the chosen workspaces; it will not appear other workspace's lists of available agent pools. Scoping an agent pool does not remove it from workspaces that are actively using it. To remove access, you must first remove the agent pool from within the workspace's settings.
+
+To scope an agent pool to specific workspaces within the organization:
+
+1. Click **Settings** and then **Agents**. A list of agent pools for the organization appears.
+
+1. Click the name of the pool you would like to update.
+
+1. Click **Grant access to specific workspaces**. A menu opens where you can search for workspaces within this organization.
+
+1. Begin typing in the search field to find available workspaces and select the workspaces that should have access to the agent pool.
+
+1. Click **Save**.
+
+Now only the specified workspaces will be able to use the agent pool.
+
 ### Revoke an Agent Token
 
 You may revoke an issued token from your agents at any time.


### PR DESCRIPTION
### What
Added information on Agents page for scoping an agent-pool to specific workspaces.

### Why
See original [Asana Ticket](https://app.asana.com/0/1198512567429989/1202095555435162/f)

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
