### PR TITLE
Update index.mdx

### DIFF
--- a/website/docs/cloud-docs/agents/index.mdx
+++ b/website/docs/cloud-docs/agents/index.mdx
@@ -181,7 +181,7 @@ export TFC_AGENT_NAME=your-agent-name
 ./tfc-agent
 ```
 
--> **Note:** The `TFC_AGENT_NAME` variable is optional. If you do not specify a name here, one will not be displayed. These names are for your reference only, and the agent ID is what will appear in logs and API requests.
+-> **Note:** The `TFC_AGENT_NAME` variable is optional. If you do not specify a name here, one will not be displayed. These names are for your reference only, and the agent ID is what will appear in logs and API requests.The limit for the name value is 64 characters. More will result in an error.
 
 Once complete, your agent will appear on the Agents page and display its current status.
 


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Added the limit for the accepted values of the TFC_AGENT_NAME environment variable.

index.mdx

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
We had a support ticket where the user was generating the names programmatically and received errors when trying to start the agent: "Error creating agent: error evaluating config: invalid agent name" so they needed to know what is the limit but this information is not listed in the documentation

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
