### PR TITLE
feat: automate release on PR merge

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,51 @@
+# This workflow publishes a GitHub release when
+# a branch with a particular pattern & version
+# is merged.
+# - ex. tfc-agent-changelog/1.2.6
+name: Publish Release on changelog branch merge
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+    paths:
+      - website/docs/cloud-docs/agents/changelog.mdx
+
+env:
+  # the branch name of the PR
+  HEAD_REF: ${{ github.head_ref }}
+
+jobs:
+  publish_release:
+    name: Publish Release
+    # only run if PR is merged
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate changelog branch
+        run: |
+          if [[ $HEAD_REF =~ ^tfc-agent-changelog/[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          then
+            echo "::notice::Branch is valid — $HEAD_REF"
+          else
+            echo "::error::Branch is invalid — $HEAD_REF"
+            exit 1
+          fi
+      - name: Get version from branch name
+        run: |
+          version=${HEAD_REF#tfc-agent-changelog/}
+          echo "VERSION=$version" >> $GITHUB_ENV
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Prepend "v"
+        run: |
+          gh release create v${{env.VERSION}} --generate-notes
+      - name: Summary
+        run: |
+          echo "# Summary"                         >> $GITHUB_STEP_SUMMARY
+          echo "**Originating Branch**: $HEAD_REF" >> $GITHUB_STEP_SUMMARY
+          echo "**Version**: v${{env.VERSION}}"    >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### What

This adds a GitHub action to run when PRs with branches like `tfc-agent-changelog/1.2.6` are merged into `main`.

The version, will be derived from the branch name, and a GitHub release will be published
- `v` will be prepended, so `v1.2.6`

### Why

This is in support of versioned-docs automation

### Screenshots

Example from test repo
- https://github.com/thiskevinwang/workflows-test/actions/runs/2720725613
- Workflow summary:

  <img width="900" alt="CleanShot 2022-07-22 at 15 24 42@2x" src="https://user-images.githubusercontent.com/26389321/180513140-f9636ac0-9e8e-4561-9cde-74e88c48ac48.png">
- Created release:
  <img width="1284" alt="CleanShot 2022-07-22 at 15 25 07@2x" src="https://user-images.githubusercontent.com/26389321/180513271-02fc0daf-ab2d-4727-9014-0d7c1aab479e.png">


