### PR TITLE
Removing outdated security warning on agents page

### DIFF
--- a/website/docs/cloud-docs/agents/agent-pools.mdx
+++ b/website/docs/cloud-docs/agents/agent-pools.mdx
@@ -19,12 +19,6 @@ Refer to [Permissions](/cloud-docs/users-teams-organizations/permissions) in the
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
-## Security Considerations
-
-!> **Warning:** We recommend carefully considering the implications of enabling agents within an organization and restricting organization access to trusted parties.
-
-Any workspace owner may configure their workspace to target the organization's agents. This action may allow a malicious workspace to access sensitive data on the host running the agent.
-
 ## Create an Agent Pool
 
 To create an agent pool:


### PR DESCRIPTION
### What
This warning predates the agent pool scoping feature, which is a practical mitigation for the attack described here. 

I think we've got an adequate explanation of our recommendations for using TFC agents in the security model, so I don't think there is a need to repeat the content here
https://developer.hashicorp.com/terraform/cloud-docs/architectural-details/security-model#use-separate-agent-pools-for-sensitive-workspaces

### Why
Correcting outdated information

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [X] Description links to related pull requests or issues, if any.

#### Content
(All checks NA)
- [X ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [X ] API documentation and the API Changelog have been updated. 
- [X ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [X ] Pages with related content are updated and link to this content when appropriate.
- [ X] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ X] New pages have metadata (page name and description) at the top.
- [ X] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [X] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [X] UI elements (button names, page names, etc.) are bolded.
- [X ] The Vercel website preview successfully deployed.

#### Reviews
- [X ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
