### PR TITLE
docs: Migrate link formats

### DIFF
--- a/.github/workflows/check-legacy-links-format.yml
+++ b/.github/workflows/check-legacy-links-format.yml
@@ -1,0 +1,17 @@
+name: Legacy Link Format Checker
+
+on:
+  push:
+    paths:
+      - "website/docs/**/*.mdx"
+      - "website/data/*-nav-data.json"
+
+jobs:
+  check-links:
+    uses: hashicorp/dev-portal/.github/workflows/docs-content-check-legacy-links-format.yml@d7c2fceac2dc41e3f857f1ce7c344141fd6a13dd
+    with:
+      repo-owner: "hashicorp"
+      repo-name: "terraform-docs-agents"
+      commit-sha: ${{ github.sha }}
+      mdx-directory: "website/docs"
+      nav-data-directory: "website/data"

--- a/.github/workflows/test-link-rewrites.yml
+++ b/.github/workflows/test-link-rewrites.yml
@@ -1,0 +1,16 @@
+name: Test Link Rewrites
+
+on: [deployment_status]
+
+jobs:
+  test-link-rewrites:
+    if: github.event.deployment_status.state == 'success'
+    uses: hashicorp/dev-portal/.github/workflows/docs-content-link-rewrites-e2e.yml@2aceb60125f6c15f4c8dbe2e4d79148047bfa437
+    with:
+      repo-owner: "hashicorp"
+      repo-name: "terraform-docs-agents"
+      commit-sha: ${{ github.sha }}
+      main-branch-preview-url: "https://terraform-docs-agents-git-main-hashicorp.vercel.app/"
+      # Workflow is only intended to run for one single migration PR
+      # This variable does not need to be updated
+      pr-branch-preview-url: "https://terraform-docs-agents-git-docs-ambmigrate-link-5503df-hashicorp.vercel.app/"

--- a/website/docs/cloud-docs/agents/agent-pools.mdx
+++ b/website/docs/cloud-docs/agents/agent-pools.mdx
@@ -13,9 +13,9 @@ Terraform Cloud organizes agents into pools. Each workspace can specify which ag
 Managing agent pools requires the following permissions:
 
 - You must be a member of the **Owners** team within your organization to manage an organization's agents.
-- You must have **Admin** access to a workspace before you can change its [execution mode](/cloud-docs/workspaces/settings#execution-mode) to use an agent pool.
+- You must have **Admin** access to a workspace before you can change its [execution mode](/terraform/cloud-docs/workspaces/settings#execution-mode) to use an agent pool.
 
-Refer to [Permissions](/cloud-docs/users-teams-organizations/permissions) in the Terraform Cloud documentation for details.
+Refer to [Permissions](/terraform/cloud-docs/users-teams-organizations/permissions) in the Terraform Cloud documentation for details.
 
 [permissions-citation]: #intentionally-unused---keep-for-maintainers
 
@@ -33,7 +33,7 @@ To create an agent pool:
 
 1. Click **Finish**.
 
-To connect an agent to this pool, [start an agent](/cloud-docs/agents/agents#start-an-agent) and provide it with the token for this agent pool.
+To connect an agent to this pool, [start an agent](/terraform/cloud-docs/agents/agents#start-an-agent) and provide it with the token for this agent pool.
 
 ## Scope an Agent Pool to Specific Workspaces
 
@@ -62,18 +62,18 @@ Use the following steps to configure a workspace to use an agent pool.
 
 ### Step 1: Manage Existing Runs
 
-Changing a workspace's [execution mode](/cloud-docs/workspaces/settings#execution-mode) after Terraform completes a plan causes that run to error during apply. To minimize these errors, do the following in the workspace before you change the execution mode:
+Changing a workspace's [execution mode](/terraform/cloud-docs/workspaces/settings#execution-mode) after Terraform completes a plan causes that run to error during apply. To minimize these errors, do the following in the workspace before you change the execution mode:
 
-1. Disable [auto-apply](/cloud-docs/workspaces/settings#auto-apply-and-manual-apply).
-1. Wait for the workspace to complete any runs that are no longer in the [pending stage](/cloud-docs/run/states#1-the-pending-stage).
-1. [Lock the workspace](/cloud-docs/workspaces/settings#locking) to prevent new runs.
+1. Disable [auto-apply](/terraform/cloud-docs/workspaces/settings#auto-apply-and-manual-apply).
+1. Wait for the workspace to complete any runs that are no longer in the [pending stage](/terraform/cloud-docs/run/states#1-the-pending-stage).
+1. [Lock the workspace](/terraform/cloud-docs/workspaces/settings#locking) to prevent new runs.
 
 ### Step 2: Select Agent Pool
 
 To configure the workspace to execute runs using an agent:
 
 1. Go to the workspace's **General Settings** page.
-1. Select **Agent** as the [execution mode](/cloud-docs/workspaces/settings#execution-mode), and select the agent pool this workspace should use.
+1. Select **Agent** as the [execution mode](/terraform/cloud-docs/workspaces/settings#execution-mode), and select the agent pool this workspace should use.
 1. Click **Save Settings**.
 
 The workspace begins using the agent for Terraform runs. Runs involving an agent include information about that agent in the run details. Terraform Cloud may use different agents for the plan and apply operations, depending on agent availability within the pool.
@@ -126,5 +126,5 @@ Agents in the **Unknown** state continue to count against the organization's tot
 
 Agents may have an **Unknown** status if they terminate without gracefully exiting. Agents should always be shut down according to the [Stopping the Agent](#stopping-the-agent) section to allow them to deregister from Terraform Cloud. To minimize **Unknown** agent statuses, we strongly recommend configuring any process supervisor, application scheduler, or other runtime manager to follow this procedure.
 
-You can deregister agents that are **Unknown**, **Errored**, or **Exited** through either the **Organization Settings > Agents** page or through the [Agent API](/cloud-docs/api-docs/agents#delete-an-agent). Deregistered agents no longer appear in the settings page or count against the organization's agent allowance.
+You can deregister agents that are **Unknown**, **Errored**, or **Exited** through either the **Organization Settings > Agents** page or through the [Agent API](/terraform/cloud-docs/api-docs/agents#delete-an-agent). Deregistered agents no longer appear in the settings page or count against the organization's agent allowance.
 

--- a/website/docs/cloud-docs/agents/agents.mdx
+++ b/website/docs/cloud-docs/agents/agents.mdx
@@ -6,7 +6,7 @@ description: >-
 
 # Install and Run Agents
 
-The agent software runs on your own infrastructure. The token you provide when starting the agent assigns it to a Terraform Cloud [agent pool](/cloud-docs/agents/agent-pools).
+The agent software runs on your own infrastructure. The token you provide when starting the agent assigns it to a Terraform Cloud [agent pool](/terraform/cloud-docs/agents/agent-pools).
 
 ## Operational Considerations
 
@@ -44,7 +44,7 @@ To customize this update behavior, pass the flag `-auto-update` or set the envir
 
 To start the agent and connect it to a Terraform Cloud agent pool:
 
-1. Retrieve the [token](/cloud-docs/agents/agent-pools#create-an-agent-pool) from the Terraform Cloud agent pool you want to use.
+1. Retrieve the [token](/terraform/cloud-docs/agents/agent-pools#create-an-agent-pool) from the Terraform Cloud agent pool you want to use.
 1. Set the `TFC_AGENT_TOKEN` environment variable.
 1. (Optional) Set the `TFC_AGENT_NAME` environment variable. This name is for your reference only. The agent ID appears in logs and API requests.
 
@@ -53,7 +53,7 @@ export TFC_AGENT_TOKEN=your-token
 export TFC_AGENT_NAME=your-agent-name
 ./tfc-agent
 ```
-Once complete, your agent and its status appear on the **Agents** page in the Terraform Cloud UI. Workspaces can now use this agent pool for runs. Refer to [Configure Workspaces to Use the Agent](/cloud-docs/agents/agent-pools#configure-workspaces-to-use-the-agent) for details.
+Once complete, your agent and its status appear on the **Agents** page in the Terraform Cloud UI. Workspaces can now use this agent pool for runs. Refer to [Configure Workspaces to Use the Agent](/terraform/cloud-docs/agents/agent-pools#configure-workspaces-to-use-the-agent) for details.
 
 ### Optional Configuration: Run an Agent Using Docker
 
@@ -91,7 +91,7 @@ To use single-execution mode, start the agent with the `-single` command line ar
 
 ## Stop the Agent
 
-~> **Important:** We strongly recommend that you only terminate the agent using one of these methods. Abruptly terminating an agent by forcefully stopping the process or power cycling the host does not let the agent deregister and results in an **Unknown** agent status. Abrupt termination may cause further capacity issues. Refer to [capacity issues](/cloud-docs/agents/agent-pools#agent-capacity-usage) for details.
+~> **Important:** We strongly recommend that you only terminate the agent using one of these methods. Abruptly terminating an agent by forcefully stopping the process or power cycling the host does not let the agent deregister and results in an **Unknown** agent status. Abrupt termination may cause further capacity issues. Refer to [capacity issues](/terraform/cloud-docs/agents/agent-pools#agent-capacity-usage) for details.
 
 The agent maintains a registration and a liveness indicator within Terraform Cloud during the entire course of its runtime. When an agent retires, it must deregister itself from Terraform Cloud. The agent deregisters automatically as part of its shutdown procedure in the following scenarios:
 

--- a/website/docs/cloud-docs/agents/index.mdx
+++ b/website/docs/cloud-docs/agents/index.mdx
@@ -18,7 +18,7 @@ The agent architecture is pull-based, so no inbound connectivity is required. An
 ## Terraform Enterprise
 
 Terraform Enterprise supports Terraform Cloud Agents. Refer to
-[Terraform Cloud Agents on TFE](/enterprise/admin/agents-on-tfe) for Terraform Enterprise specific documentation and requirements.
+[Terraform Cloud Agents on TFE](/terraform/enterprise/admin/agents-on-tfe) for Terraform Enterprise specific documentation and requirements.
 
 ## Limitations
 
@@ -27,7 +27,7 @@ Agents allow you to run Terraform operations from a Terraform Cloud workspace on
 - Connecting to private infrastructure from Sentinel policies using the [http import](https://docs.hashicorp.com/sentinel/imports/http).
 - Connecting Terraform Cloud workspaces to VCS instances that do not allow access from the public internet. For example, you cannot use agents to connect to a GitHub Enterprise Server instance that requires access to your VPN.
 
-For these use cases, we recommend you leverage the information provided by the [IP Ranges documentation](/cloud-docs/architectural-details/ip-ranges) to permit direct communication from the appropriate Terraform Cloud service to your internal infrastructure.
+For these use cases, we recommend you leverage the information provided by the [IP Ranges documentation](/terraform/cloud-docs/architectural-details/ip-ranges) to permit direct communication from the appropriate Terraform Cloud service to your internal infrastructure.
 
 
 

--- a/website/docs/cloud-docs/agents/requirements.mdx
+++ b/website/docs/cloud-docs/agents/requirements.mdx
@@ -7,7 +7,7 @@ description: >-
 # Requirements
 ~> Important: All agents in an agent pool should have the same operating system and hardware resources available. If the agents are using different resources, run performance can vary significantly between each agent in the pool.
 
-Ensure your system meets the following requirements before installing and configuring Terraform Cloud Agents. Refer to [Terraform Cloud Agents on TFE](/enterprise/admin/agents-on-tfe) for additional Terraform Enterprise requirements.
+Ensure your system meets the following requirements before installing and configuring Terraform Cloud Agents. Refer to [Terraform Cloud Agents on TFE](/terraform/enterprise/admin/agents-on-tfe) for additional Terraform Enterprise requirements.
 
 
 ## Supported Operating Systems
@@ -30,7 +30,7 @@ Use the following specifications as a reference:
 
 ## Networking Requirements
 
-In order for an agent to function properly, it must be able to make outbound requests over HTTPS (TCP port 443) to the Terraform Cloud application APIs. These requests may require perimeter networking as well as container host networking changes, depending on your environment. Refer to the [Terraform Cloud IP Ranges documentation](/cloud-docs/architectural-details/ip-ranges) for more details on the IP ranges.
+In order for an agent to function properly, it must be able to make outbound requests over HTTPS (TCP port 443) to the Terraform Cloud application APIs. These requests may require perimeter networking as well as container host networking changes, depending on your environment. Refer to the [Terraform Cloud IP Ranges documentation](/terraform/cloud-docs/architectural-details/ip-ranges) for more details on the IP ranges.
 
 Additionally, the agent must also be able to communicate with any services required by the Terraform code it is executing. This includes the Terraform releases distribution service, [releases.hashicorp.com](https://releases.hashicorp.com) (supported by [Fastly](https://api.fastly.com/public-ip-list)), as well as any provider APIs. The following services run on these IP ranges:
 

--- a/website/docs/cloud-docs/agents/telemetry.mdx
+++ b/website/docs/cloud-docs/agents/telemetry.mdx
@@ -96,7 +96,7 @@ The collector should start with your modified configuration.
 The agent emits tracing spans which are useful in understanding and debugging
 various operations performed by the Terraform Cloud Agent.
 
-See the [Tracing](./tracing) documentation for details.
+See the [Tracing](/terraform/cloud-docs/agents/tracing) documentation for details.
 
 ## Metrics
 
@@ -104,4 +104,4 @@ Terraform Cloud Agents emit granular metrics which are useful in understanding
 the behavior and performance of various operations in a high-level, aggregated
 view.
 
-See the [Metrics](./metrics) documentation for details.
+See the [Metrics](/terraform/cloud-docs/agents/metrics) documentation for details.


### PR DESCRIPTION
## What

- Migrates the formats of links in Markdown content as part of the [Docs Content Link Rewrites project](https://docs.google.com/document/d/1WaSyvoVPS-YCNiSPX0ynGpvc1gySEcpbrRoQVhimQCA/edit)
- Adds two new GitHub workflow files:
  - `.github/workflows/check-legacy-links-format.yml` - This is a workflow that checks if links in markdown content are in the new format. It does this by running the link rewrite script from `dev-portal`, and then asserting that no "rewriteable" links were found. This workflow will be used on subsequent PRs to maintain the new link format.
  - `.github/workflows/test-link-rewrites.yml` - This is a workflow that executes e2e tests of this PR's changes against the `main` branch's deploy preview. The tests only run for branches named `docs/amb.migrate-link-formats`, so future PRs will not have the tests run against them. This is a temporary workflow.

## Reviewing

With the two new workflows in place, this PR should only need a spot-check.

## Testing

- [ ] The latest run of the "Legacy Link Format Checker" workflow for this branch should pass ([check here](https://github.com/hashicorp/terraform-docs-agents/actions/workflows/check-legacy-links-format.yml))
- [ ] The latest run of the "Test Link Rewrites" workflow for this branch should pass ([check here](https://github.com/hashicorp/terraform-docs-agents/actions/workflows/test-link-rewrites.yml))


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203534392784695
  - https://app.asana.com/0/0/1203715368770951
