### PR TITLE
Fix missing TFC Agent configuration link

### DIFF
--- a/website/docs/cloud-docs/agents/telemetry.mdx
+++ b/website/docs/cloud-docs/agents/telemetry.mdx
@@ -102,7 +102,7 @@ connections, refer to the [DataDog OpenTelemetry
 documentation](https://docs.datadoghq.com/opentelemetry/otlp_ingest_in_the_agent).
 Note that the tfc-agent talks to a gRPC OTLP receiver only. Be sure to
 configure the DataDog agent to accept a gRPC OTLP connection. Once the
-DataDog agent is listening for gRPC connections, [configure the tfc-agent] using
+DataDog agent is listening for gRPC connections, [configure the tfc-agent](/terraform/cloud-docs/agents/telemetry#agent-configuration) using
 the address of the DataDog agent's gRPC listener in place of the OpenTelemetry
 collector address.
 


### PR DESCRIPTION
### What
Adds the link to configure the TFC Agent for OTEL

### Why
The markdown link rendering was previously incomplete.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
