### PR TITLE
Update hooks.mdx

### DIFF
--- a/website/docs/cloud-docs/agents/hooks.mdx
+++ b/website/docs/cloud-docs/agents/hooks.mdx
@@ -169,7 +169,7 @@ example creates a `pre-plan` hook that prints a message when it runs.
 
   ```
   FROM hashicorp/tfc-agent:latest
-  RUN mkdir /home/tfc-agent/.tfc-agent
+  RUN mkdir -p /home/tfc-agent/.tfc-agent
   ADD --chown=tfc-agent:tfc-agent hooks /home/tfc-agent/.tfc-agent/hooks
   ```
 


### PR DESCRIPTION
In the current Docker image for `hashicorp/tfc-agent:latest` , this directory already exists `/home/tfc-agent/.tfc-agent`

This PR is to update command to not fail if the directory exists.

Please update to:

```
RUN mkdir -p /home/tfc-agent/.tfc-agent
```

I am sharing a screenshot for the reference of where `-p` should be placed in our documentation.

![Screenshot 2023-05-31 at 09 11 47](https://github.com/hashicorp/terraform-docs-agents/assets/75247430/a75b5375-208c-48fe-95cc-c19bc8a5f809)
