### PR TITLE
Add missing sentinel metrics to the docs

### DIFF
--- a/website/docs/cloud-docs/agents/metrics.mdx
+++ b/website/docs/cloud-docs/agents/metrics.mdx
@@ -152,3 +152,5 @@ section are prefixed by `tfc-agent.core.policy.`.
 | `setup_policies.milliseconds`                  | Timer | Time spent setting up individually managed policies.     |
 | `setup_policy_engines.milliseconds`            | Timer | Time spent setting up policy runtimes.                   |
 | `setup_subjects.milliseconds`                  | Timer | Time spent setting up subjects for policy enforcement.   |
+| `write-sentinel-config.milliseconds`           | Timer | Time spent generating the Sentinel config file.          |
+| `run-sentinel-apply.milliseconds`              | Timer | Time spent evaluating Sentinel policies.                 |

--- a/website/docs/cloud-docs/agents/metrics.mdx
+++ b/website/docs/cloud-docs/agents/metrics.mdx
@@ -152,5 +152,5 @@ section are prefixed by `tfc-agent.core.policy.`.
 | `setup_policies.milliseconds`                  | Timer | Time spent setting up individually managed policies.     |
 | `setup_policy_engines.milliseconds`            | Timer | Time spent setting up policy runtimes.                   |
 | `setup_subjects.milliseconds`                  | Timer | Time spent setting up subjects for policy enforcement.   |
-| `write-sentinel-config.milliseconds`           | Timer | Time spent generating the Sentinel config file.          |
-| `run-sentinel-apply.milliseconds`              | Timer | Time spent evaluating Sentinel policies.                 |
+| `write_sentinel_config.milliseconds`           | Timer | Time spent generating the Sentinel config file.          |
+| `run_sentinel_apply.milliseconds`              | Timer | Time spent evaluating Sentinel policies.                 |


### PR DESCRIPTION
### What
Add sentinel metrics to the Metrics - Terraform Cloud Agents docs
**NOTE: This needs the tfc-agent changes to be released before merging!!!!**

### Why
Sentinel metrics are missing


### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. tfc).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] API documentation and the API Changelog have been updated. 
- [x] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] Pages with related content are updated and link to this content when appropriate.
- [x] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] New pages have metadata (page name and description) at the top.
- [x] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
