### PR TITLE
Updates for tfc-agent release 1.15.5

### DIFF
--- a/website/docs/cloud-docs/agents/changelog.mdx
+++ b/website/docs/cloud-docs/agents/changelog.mdx
@@ -18,6 +18,16 @@ within each release are categorized into one or more of the following labels:
 Each version below corresponds to a release artifact available for download on
 the official [releases website](https://releases.hashicorp.com/tfc-agent/).
 
+## 1.15.5 (09/18/2024)
+
+IMPROVEMENTS:
+
+* Included a copy of the license text with all releases (#772)
+
+SECURITY:
+
+* Moved to building with Go 1.22.7 in which several CVEs are addressed (#781)
+
 ## 1.15.4 (07/24/2024)
 
 SECURITY:


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->

TFC Agent `v1.15.5`.
