### PR TITLE
Updates for tfc-agent release 1.16.0

### DIFF
--- a/website/docs/cloud-docs/agents/changelog.mdx
+++ b/website/docs/cloud-docs/agents/changelog.mdx
@@ -18,6 +18,12 @@ within each release are categorized into one or more of the following labels:
 Each version below corresponds to a release artifact available for download on
 the official [releases website](https://releases.hashicorp.com/tfc-agent/).
 
+## 1.16.0 (10/02/2024)
+
+FEATURES:
+
+* Added support for authenticating with AWS and GCP using dynamic credentials generated via HCP Vault Secrets (#786)
+
 ## 1.15.5 (09/18/2024)
 
 IMPROVEMENTS:


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->

TFC Agent `v1.16.0`.