### PR TITLE
Changing the link which forwards to the yaml config of the collector

### DIFF
--- a/website/docs/cloud-docs/agents/telemetry.mdx
+++ b/website/docs/cloud-docs/agents/telemetry.mdx
@@ -80,7 +80,7 @@ the HCP Terraform Agent can talk to) on port 4317 of the local machine.
 The OpenTelemetry collector takes configuration in the form of a YAML file. It
 may be useful to refer to the default YAML configuration file as a starting
 point for your own configuration. Its source may be found
-[here](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/configs/otelcol-contrib.yaml).
+[here](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/distributions/otelcol-contrib/config.yaml).
 
 To tweak the configuration, save your custom YAML configuration to a file on
 disk called `collector.yaml`, and run the collector container with the

--- a/website/docs/cloud-docs/agents/telemetry.mdx
+++ b/website/docs/cloud-docs/agents/telemetry.mdx
@@ -78,9 +78,6 @@ the HCP Terraform Agent can talk to) on port 4317 of the local machine.
 ### Configuring the collector
 
 The OpenTelemetry collector takes configuration in the form of a YAML file. Refer to the [default YAML configuration file](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/distributions/otelcol-contrib/config.yaml) as a starting point for writing your own configuration.
-may be useful to refer to the default YAML configuration file as a starting
-point for your own configuration. Its source may be found
-[here](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/distributions/otelcol-contrib/config.yaml).
 
 To tweak the configuration, save your custom YAML configuration to a file on
 disk called `collector.yaml`, and run the collector container with the

--- a/website/docs/cloud-docs/agents/telemetry.mdx
+++ b/website/docs/cloud-docs/agents/telemetry.mdx
@@ -77,7 +77,7 @@ the HCP Terraform Agent can talk to) on port 4317 of the local machine.
 
 ### Configuring the collector
 
-The OpenTelemetry collector takes configuration in the form of a YAML file. It
+The OpenTelemetry collector takes configuration in the form of a YAML file. Refer to the [default YAML configuration file](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/distributions/otelcol-contrib/config.yaml) as a starting point for writing your own configuration.
 may be useful to refer to the default YAML configuration file as a starting
 point for your own configuration. Its source may be found
 [here](https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/distributions/otelcol-contrib/config.yaml).


### PR DESCRIPTION
### What

I have changed the link which bring the user to the example configuration of the collector, since the current one leads to an not found github page.

### Why

To make the documentation more accurate.

### Screenshots

This is the result of the current link:

<img width="1603" alt="image" src="https://github.com/user-attachments/assets/af5c8b55-3bd5-423e-b26b-77a08546e061">


----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ + ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ + ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ + ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ + ] I or someone else reviewed the content for technical accuracy.
- [ + ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
