### PR TITLE
Mentioned the requirement to accept ingress jobs by agent use for PVCS

### DIFF
--- a/website/docs/cloud-docs/agents/request-forwarding.mdx
+++ b/website/docs/cloud-docs/agents/request-forwarding.mdx
@@ -38,6 +38,7 @@ of accessing the target API.
 
 ## Agent Configuration
 
+### Enable request forwarding
 To enable request forwarding, start the agent with the `-request-forwarding`
 flag, or set the environment variable `TFC_AGENT_REQUEST_FORWARDING=true`. When
 the agent starts, you will see the following log messages:
@@ -49,6 +50,13 @@ the agent starts, you will see the following log messages:
 
 These log messages indicate that the agent has successfully connected to HCP Terraform
 and is ready to start forwarding requests.
+
+### (Optional) Accept ingress jobs needed for Private VCS access
+By default, HCP Terraform will try to clone a repository using its own infrastructure.
+For Private repository access to work, Configuration Version(CV) ingress needs to happen through the agent.
+For this ingress job type to be accepted, agent must be started with `-accept` containing `ingress`.
+This job type is disabled in the default configuration.
+Skipping this configuration step will result in timeout Configuration Version errors being shown when PVCS is used.
 
 ## Requirements and Limitations
 

--- a/website/docs/cloud-docs/agents/request-forwarding.mdx
+++ b/website/docs/cloud-docs/agents/request-forwarding.mdx
@@ -51,7 +51,7 @@ These log messages indicate that the agent has successfully connected to HCP Ter
 and is ready to start forwarding requests.
 
 ### Optionally accept ingress jobs to access a private VCS
-By default, HCP Terraform will try to clone a repository using its own infrastructure.
+If you want to use a private VCS provider, you must configure your HCP Terraform agent to support private VCS by allowing access to those private repositories. To learn more, refer to [Connect to Private VCS Providers](/terraform/cloud-docs/vcs/private#configure-the-agent-pool-and-agent). 
 For Private repository access to work, Configuration Version(CV) ingress needs to happen through the agent.
 For this ingress job type to be accepted, agent must be started with `-accept` containing `ingress`.
 This job type is disabled in the default configuration.

--- a/website/docs/cloud-docs/agents/request-forwarding.mdx
+++ b/website/docs/cloud-docs/agents/request-forwarding.mdx
@@ -50,7 +50,7 @@ the agent starts, you will see the following log messages:
 These log messages indicate that the agent has successfully connected to HCP Terraform
 and is ready to start forwarding requests.
 
-### (Optional) Accept ingress jobs needed for Private VCS access
+### Optionally accept ingress jobs to access a private VCS
 By default, HCP Terraform will try to clone a repository using its own infrastructure.
 For Private repository access to work, Configuration Version(CV) ingress needs to happen through the agent.
 For this ingress job type to be accepted, agent must be started with `-accept` containing `ingress`.

--- a/website/docs/cloud-docs/agents/request-forwarding.mdx
+++ b/website/docs/cloud-docs/agents/request-forwarding.mdx
@@ -38,7 +38,6 @@ of accessing the target API.
 
 ## Agent Configuration
 
-### Enable request forwarding
 To enable request forwarding, start the agent with the `-request-forwarding`
 flag, or set the environment variable `TFC_AGENT_REQUEST_FORWARDING=true`. When
 the agent starts, you will see the following log messages:


### PR DESCRIPTION
### What
 Mentioned the requirement to accept ingress jobs by agent use for PVCS

### Why
Ingress job is required to be passed to `-accept` for PVCS to work. This is not yet mentioned and disabled by default.

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
