### PR TITLE
Customer Hook Timeout

### DIFF
--- a/website/docs/cloud-docs/agents/hooks.mdx
+++ b/website/docs/cloud-docs/agents/hooks.mdx
@@ -42,14 +42,17 @@ Please note the following behavior when using hooks:
 	create a `pre-plan` and `pre-apply` hook, but you cannot create two
 	`pre-plan` hooks.
 - Each hook must have the execute permission set.
-- Each hook has a 60 second timeout. If a hook times out the Terraform run will
-	fail immediately.
-- Environment variables do not persist across hooks. For example, if a
+- Each hook has a default timeout of 60 seconds and a max timeout of 10 minutes. 
+  The timeout for each hook can be configured, in seconds, using an environment 
+  variable with a hook specific name `TFC_AGENT_HOOK_[HOOK NAME]_TIMEOUT`. An example 
+  of setting the timeout for the pre-plan hook to 2 minutes is `TFC_AGENT_HOOK_PREPLAN_TIMEOUT=120`.
+  If a hook times out the Terraform run will fail immediately.
+- Environment variables for terraform do not persist across hooks. For example, if a
   `pre-plan` hook exports environment variables, they will not be available
   during the `post-plan` hook. Similarly, if `terraform plan` exports
   environment variables, they will not be available during the `post-plan` hook.
 
-## Setting environment variables
+## Setting Terraform Environment Variables
 
 Hooks may be used to set environment variables for subsequent `terraform`
 commands to use. To set an environment variable, write lines in `KEY=value`


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Hooks.mdx
- added information about the new feature where a custom timeout can be set for a hook

### Why
<!-- Explain why this change is necessary and how it benefits users. -->
A new customer who is onboarding to TFC has a pre-plan script which takes longer than 60 seconds to run. To fix this issue we are adding the ability for the hooks to have their default timeout overridden by an environment variable. 

### Screenshots
<!-- Optional. Show additions to the sidebar or new formatting. -->

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [ ] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform).
- [ ] Description links to related pull requests or issues, if any.

#### Content
- [ ] Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [ ] API documentation and the API Changelog have been updated. 
- [ ] Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [ ] Pages with related content are updated and link to this content when appropriate.
- [ ] Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [ ] New pages have metadata (page name and description) at the top.
- [ ] New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [ ] New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [ ] UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
