### PR TITLE
Updates for tfc-agent release 1.18.0

### DIFF
--- a/website/docs/cloud-docs/agents/changelog.mdx
+++ b/website/docs/cloud-docs/agents/changelog.mdx
@@ -55,6 +55,7 @@ BUG FIXES:
 ## 1.17.2 (11/26/2024)
 
 IMPROVEMENTS:
+
 * Added jitter to connection retries for Request Forwarding (#817)
 * Ensured ephemeral variables (Terraform v1.10 feature) are passed between plan & apply (#831)
 

--- a/website/docs/cloud-docs/agents/changelog.mdx
+++ b/website/docs/cloud-docs/agents/changelog.mdx
@@ -18,10 +18,22 @@ within each release are categorized into one or more of the following labels:
 Each version below corresponds to a release artifact available for download on
 the official [releases website](https://releases.hashicorp.com/tfc-agent/).
 
+## 1.18.0 (01/29/2025)
+
+FEATURES:
+* Added ability to check for private module versions that are deprecated and display deprecation warnings in the run output (#879)
+
+SECURITY:
+* Update dependency `github.com/hashicorp/go-slug` to `v0.16.4` (#892)
+   - This resolves [CVE-2025-0377 in hashicorp/go-slug](https://discuss.hashicorp.com/t/hcsec-2025-01-hashicorp-go-slug-vulnerable-to-zip-slip-attack/72719).
+   - Fixes a bug which caused tfc-agent:v1.17.6 to break on certain API-driven workflows in HCP Terraform and Terraform Enterprise.
+
 ## 1.17.6 (01/23/2025)
 
 SECURITY:
 * Update dependency `github.com/hashicorp/go-slug` to `v0.16.3` (#867)
+   - **Important:** v0.16.3 of go-slug contained a bug which caused tfc-agent:v1.17.6 to break on certain API-driven workflows in HCP Terraform and Terraform Enterprise.
+   - This resolves [CVE-2025-0377 in hashicorp/go-slug](https://discuss.hashicorp.com/t/hcsec-2025-01-hashicorp-go-slug-vulnerable-to-zip-slip-attack/72719).
 * Update dependencies `github.com/go-git/go-git/v5` to `v5.13.1` and `golang.org/x/net` to `v0.34.0` (#873)
 
 ## 1.17.5 (12/12/2024)

--- a/website/docs/cloud-docs/agents/changelog.mdx
+++ b/website/docs/cloud-docs/agents/changelog.mdx
@@ -55,7 +55,6 @@ BUG FIXES:
 ## 1.17.2 (11/26/2024)
 
 IMPROVEMENTS:
-
 * Added jitter to connection retries for Request Forwarding (#817)
 * Ensured ephemeral variables (Terraform v1.10 feature) are passed between plan & apply (#831)
 


### PR DESCRIPTION
### What
This PR updates to tfc-agent docs for the 1.18.0 release. It also adds some additional context to the docs for the 1.17.6 release around the go-slug updates.

### Why
This is a routine part of release new versions of the agent.

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform).
- [x] Description links to related pull requests or issues, if any.

#### Content
- [x] N/A - Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] N/A - API documentation and the API Changelog have been updated. 
- [x] N/A - Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] N/A - Pages with related content are updated and link to this content when appropriate.
- [x] N/A - Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] N/A - New pages have metadata (page name and description) at the top.
- [x] N/A - New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] N/A - New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] N/A - UI elements (button names, page names, etc.) are bolded.
- [ ] The Vercel website preview successfully deployed.

#### Reviews
- [x] I or someone else reviewed the content for technical accuracy.
- [x] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
