### PR TITLE
Updates for tfc-agent release 1.20.2

### DIFF
--- a/website/docs/cloud-docs/agents/changelog.mdx
+++ b/website/docs/cloud-docs/agents/changelog.mdx
@@ -18,6 +18,13 @@ within each release are categorized into one or more of the following labels:
 Each version below corresponds to a release artifact available for download on
 the official [releases website](https://releases.hashicorp.com/tfc-agent/).
 
+## 1.20.2 (03/04/2025)
+
+SECURITY:
+
+* Updated golang.org/x/crypto dependency to v0.35.0 to address GO-2025-3487 (#935)
+* Updated golang.org/x/oauth2 dependency to v0.27.0 to address GO-2025-3488 (#935)
+
 ## 1.20.1 (02/19/2025)
 
 BUG FIXES:


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->

Agent `v1.20.2` release. 
