### PR TITLE
Updates for tfc-agent release 1.21.0

### DIFF
--- a/website/docs/cloud-docs/agents/changelog.mdx
+++ b/website/docs/cloud-docs/agents/changelog.mdx
@@ -18,6 +18,12 @@ within each release are categorized into one or more of the following labels:
 Each version below corresponds to a release artifact available for download on
 the official [releases website](https://releases.hashicorp.com/tfc-agent/).
 
+## 1.21.0 (03/18/2025)
+
+IMPROVEMENTS:
+
+* Upgraded Ubuntu to `v24.04` for base Docker image. (#922)
+
 ## 1.20.2 (03/04/2025)
 
 SECURITY:


### PR DESCRIPTION
### What
<!-- Explain what you changed and provide a list of changed page names. -->
Agent `v1.21.0` release.