### PR TITLE
Update docs for request forwarding GA

### DIFF
--- a/website/docs/cloud-docs/agents/request-forwarding.mdx
+++ b/website/docs/cloud-docs/agents/request-forwarding.mdx
@@ -59,7 +59,7 @@ If you want to use a private VCS provider, you must configure your HCP Terraform
 
 ## Requirements and Limitations
 
-Agent version 1.15.0+ is required to use request forwarding.
+Agent version 1.21.1+ is required to use request forwarding.
 
 We recommend that you allocate at least 250MB of additional system memory specifically
 for request forwarding. This is in addition to the minimum


### PR DESCRIPTION
### What
This PR updates the request forwarding docs to indicate the minimum agent version required. This is the version we will be releasing tomorrow.

### Why
We need to have the minimum required version documented for GA

### Screenshots
<img width="767" alt="Screenshot 2025-03-31 at 3 49 32 PM" src="https://github.com/user-attachments/assets/f6453bab-6c30-4d39-abac-102f5ec96a6f" />

----------

### Merge Checklist
_If items do not apply to your changes, add (N/A) and mark them as complete._

#### Pull Request
- [x] One or more labels describe the type of change (e.g. clarification) and associated product (e.g. HCP Terraform).
- [x] (N/A) Description links to related pull requests or issues, if any.

#### Content
- [x] (N/A) Redirects have been added for moved, renamed, or deleted pages. This requires a separate PR in the [`terraform-website` repository](https://github.com/hashicorp/terraform-website) `redirects.next.js` file.
- [x] (N/A) API documentation and the API Changelog have been updated. 
- [x] (N/A) Links to related content where appropriate (e.g., API endpoints, permissions, etc.).
- [x] (N/A) Pages with related content are updated and link to this content when appropriate.
- [x] (N/A) Sidebar navigation files have been updated for added, deleted, reordered, or renamed pages.
- [x] (N/A) New pages have metadata (page name and description) at the top.
- [x] (N/A) New images are 2048 px wide. They have HashiCorp standard annotation color (#F92672) and format (rectangle with rounded corners), blurred sensitive details (e.g. credentials, usernames, user icons), and descriptive alt text in the markdown for accessibility.
- [x] (N/A) New code blocks have the correct syntax and line breaks to eliminate horizontal scroll bars.
- [x] (N/A) UI elements (button names, page names, etc.) are bolded.
- [x] The Vercel website preview successfully deployed.

#### Reviews
- [ ] I or someone else reviewed the content for technical accuracy.
- [ ] I or someone else reviewed the content for typos, punctuation, spelling, and grammar.
